### PR TITLE
Fix newlines not getting parsed

### DIFF
--- a/main.go
+++ b/main.go
@@ -516,13 +516,16 @@ func (m *Model) RenderDocumentView() string {
 		}
 		key := logoStyle.Render(colname)
 		val := strings.Map(func(r rune) rune {
-			if unicode.IsPrint(r) {
+			if unicode.IsPrint(r) || r == '\n' {
 				return r
 			}
 			return -1
 		}, string(r))
 		if val == "null" {
 			val = lipgloss.NewStyle().Foreground(lipgloss.Color("#474747")).Render(val)
+		} else {
+			coloredReturn := lipgloss.NewStyle().Foreground(lipgloss.Color("#e07a00")).Render("↵")
+			val = strings.ReplaceAll(val, "\\n", coloredReturn+"\n")
 		}
 		content.WriteString(fmt.Sprintf("%v%v : %v\n", key, strings.Repeat(" ", maxWidth-len(colname)), val))
 	}


### PR DESCRIPTION
Added a case for rune checking to also check for newline.

Also added a colored return symbol to indicate a newline is taking place in the text itself, and not just from the marshaler, MarshalIndent

Before: 
![image](https://github.com/nokusukun/bingoviewer/assets/145195760/154e8360-8442-46e8-88a3-ac5fc2fbb68a)

After:
![image](https://github.com/nokusukun/bingoviewer/assets/145195760/cbe851b4-3f76-48c5-b5a1-6312cef20378)
